### PR TITLE
Fix DEFAULT_FROM_EMAIL

### DIFF
--- a/conf/local.py
+++ b/conf/local.py
@@ -33,8 +33,6 @@ DATABASES = {
     },
 }
 
-DEFAULT_FROM_EMAIL = "YNH_APP_ARG_EMAIL"
-
 FEEDS = (('isp', 'http://www.illyse.net/feed/', 3),
          ('ffdn', 'http://www.ffdn.org/fr/rss.xml', 3))
 


### PR DESCRIPTION
`DEFAULT_FROM_EMAIL` settings is already defined as `notifier@YNH_APP_ARG_DOMAIN` so don't override this settings.