### PR TITLE
Fix conflic name

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -8,12 +8,12 @@ source /usr/share/yunohost/helpers
 source future.sh
 source common.sh
 
-readonly app=$YNH_APP_INSTANCE_NAME
+app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve arguments
-readonly domain=$YNH_APP_ARG_DOMAIN
+domain=$YNH_APP_ARG_DOMAIN
 #readonly path=$YNH_APP_ARG_PATH
-readonly path=/
+path=/
 
 readonly admin=$YNH_APP_ARG_ADMIN
 readonly email=$YNH_APP_ARG_EMAIL


### PR DESCRIPTION
# Problem

The app is broken by the conflict with the `$app`, `$domain` and the `$path` variable. We can see this error : 
```
27751 DEBUG + readonly app=coin
27751 DEBUG + app=coin
27751 DEBUG + readonly domain=swissneutral.net
27751 DEBUG + domain=swissneutral.net
27752 DEBUG + readonly path=/
27752 DEBUG + path=/
27752 DEBUG + readonly admin=josue
27752 DEBUG + admin=josue
27753 DEBUG + readonly email=josue@swissneutral.net
27753 DEBUG + email=josue@swissneutral.net
27753 DEBUG + readonly isp_name=SwissneutralNet
27753 DEBUG + isp_name=SwissneutralNet
27754 DEBUG + readonly isp_site=www.swissneutral.ent
27754 DEBUG + isp_site=www.swissneutral.ent
27754 DEBUG ++ ynh_string_random 24
27754 DEBUG ++ sed -n 's/\(.\{24\}\).*/\1/p'
27754 DEBUG ++ tr -c -d A-Za-z0-9
27755 DEBUG ++ dd if=/dev/urandom bs=1 count=1000
27755 DEBUG + readonly secret=DMYsQA3FrRGPc6dX8aNr4foH
27755 DEBUG + secret=DMYsQA3FrRGPc6dX8aNr4foH
27755 DEBUG + ynh_user_exists josue
27756 DEBUG + sudo yunohost user list --output-as json
27756 DEBUG + grep -q '"username": "josue"'
28157 DEBUG + configure_app
28158 WARNING /usr/share/yunohost/helpers.d/network: ligne 63 : local: app : variable en lecture seule
28158 DEBUG + ynh_webpath_register coin swissneutral.net /
28158 DEBUG + local app=coin
```
# Solution

Do a dirty fix. Don't set this variable as readonly.

Maybe you have a better idea ?