### PR TITLE
Use metapackage for PostgreSQL dev libraries.

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -68,7 +68,7 @@ ram.runtime = "50M"
     main.allowed = "visitors"
 
     [resources.apt]
-    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev"
+    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev-all"
 
     [resources.database]
     type = "postgresql"

--- a/manifest.toml
+++ b/manifest.toml
@@ -68,7 +68,7 @@ ram.runtime = "50M"
     main.allowed = "visitors"
 
     [resources.apt]
-    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev-all"
+    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev-all python3-dev"
 
     [resources.database]
     type = "postgresql"

--- a/manifest.toml
+++ b/manifest.toml
@@ -68,7 +68,7 @@ ram.runtime = "50M"
     main.allowed = "visitors"
 
     [resources.apt]
-    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev-13"
+    packages = "gunicorn, python3, python3-venv, libpq-dev, libsasl2-dev, libjpeg-dev, libxml2-dev, libxslt1-dev, libpango1.0-0, postgresql, postgresql-contrib, postgresql-server-dev"
 
     [resources.database]
     type = "postgresql"

--- a/sources/patches/main-001.patch
+++ b/sources/patches/main-001.patch
@@ -1,0 +1,21 @@
+From 43585e806da2002b4b070489e2f6db6aafb3ca2f Mon Sep 17 00:00:00 2001
+From: orhtej2 <2871798+orhtej2@users.noreply.github.com>
+Date: Sat, 10 Feb 2024 20:01:35 +0100
+Subject: [PATCH] Use newer Psycopg
+
+---
+ exporter/src/app/browser.cljs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/requirements.txt b/requierement.txt
+index 3cbcf2b98..c2c44e774 100644
+--- a/requirements.txt
++++ b/requierement.txt
+@@ -2,1 +2,1 @@
+Django>=2.2,<2.3
+- psycopg2>=2.8,<2.9
++ psycopg2>=2.9,<3.0
+# To match django-ldapdb version:
+#python-ldap>=3.0,<3.
+-- 
+2.42.0.windows.2

--- a/sources/patches/main-001.patch
+++ b/sources/patches/main-001.patch
@@ -1,21 +1,11 @@
-From 43585e806da2002b4b070489e2f6db6aafb3ca2f Mon Sep 17 00:00:00 2001
-From: orhtej2 <2871798+orhtej2@users.noreply.github.com>
-Date: Sat, 10 Feb 2024 20:01:35 +0100
-Subject: [PATCH] Use newer Psycopg
-
----
- exporter/src/app/browser.cljs | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/requirements.txt b/requierement.txt
-index 3cbcf2b98..c2c44e774 100644
+diff --git a/requirements.txt b/requirements.txt
+index 27c1a5c..a21fd3d 100644
 --- a/requirements.txt
-+++ b/requierement.txt
-@@ -2,1 +2,1 @@
-Django>=2.2,<2.3
-- psycopg2>=2.8,<2.9
-+ psycopg2>=2.9,<3.0
-# To match django-ldapdb version:
-#python-ldap>=3.0,<3.
--- 
-2.42.0.windows.2
++++ b/requirements.txt
+@@ -1,5 +1,5 @@
+ Django>=2.2,<2.3
+-psycopg2>=2.8,<2.9
++psycopg2>=2.9,<3.0
+ # To match django-ldapdb version:
+ #python-ldap>=3.0,<3.1
+ #wsgiref


### PR DESCRIPTION
## Problem

- Bookworm compatibility

## Solution

- Let `apt` choose `PostgreSQL` version.
- Bump `psycopg2` dependency to 2.9 for improved Python 3.11 support.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
